### PR TITLE
cache RDD for K-means

### DIFF
--- a/src/main/scala/KMeans.scala
+++ b/src/main/scala/KMeans.scala
@@ -33,7 +33,7 @@ object KMeans {
     println("Start KMeans training...")
     // Load and parse the data
     val data = sc.textFile(filename, splits)
-    val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble)))
+    val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
 
     val clusters = MLLibKMeans.train(parsedData, k, iterations)
     //val clusters = org.apache.spark.mllib.clustering.KMeans.train(parsedData, k, iterations)


### PR DESCRIPTION
As shown in [comments from Spark source code](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala#L38), K-means is an iterative algorithm that will make multiple passes over the data, so any RDDs given to it should be cached by the user.
This patch is orders of magnitude faster than the original version.
